### PR TITLE
Add routing with react-router for app navigation

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import App from './App.jsx'
 import './index.css'
+import { RouterProvider } from 'react-router-dom'
+import { router } from './router'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>,
 )

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,0 +1,54 @@
+import { createBrowserRouter, Navigate, Outlet } from "react-router-dom"
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    errorElement: <h1>Error Page</h1>,
+    children: [
+      { index: true, element: <h1>Welcome Page</h1> },
+      {
+        element: <Outlet />,
+        children: [
+          {
+            path: "/app",
+            children: [
+              {
+                index: true,
+                element: <Navigate to="dashboard" replace />,
+              },
+              {
+                path: "dashboard",
+                element: <h1>Dashboard Page</h1>,
+              },
+              {
+                path: "groups",
+                children: [
+                  {
+                    index: true,
+                    element: <h1>Groups List Page</h1>,
+                  },
+                  {
+                    path: "new",
+                    element: <h1>New Expense Group Page</h1>,
+                  },
+                  {
+                    path: ":groupId",
+                    children: [
+                      { index: true, element: <h1>Dynamic Expense Group Page</h1> },
+                      { path: "edit", element: <h1>Dynamic Page for Editing an Expense Group</h1> },
+                    ],
+                  },
+                ],
+              },
+              {
+                path: "friends",
+                element: <h1>Friends List Page</h1>,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  { path: "*", element: <h1>404 Page</h1> },
+])


### PR DESCRIPTION
Implemented routing for all pages using object syntax.

- Added h1 elements as placeholders for future pages.
- Added placeholders for the error page and the 404 page.
- Future pages can be imported into the router and replace the corresponding placeholders once completed.
- In the `main.jsx` file, the App component has been replaced with the `RouterProvider `component from react-router.
I suggest deleting the `App.jsx` file, as it is no longer necessary.