### PR TITLE
Refactor Forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,10 @@
         "@stepperize/react": "^3.0.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "date-fns": "^3.6.0",
         "lucide-react": "^0.439.0",
         "react": "^18.3.1",
+        "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
         "react-router-dom": "^6.26.1",
@@ -2354,6 +2356,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -4733,6 +4745,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0 || ^3.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -25,15 +25,17 @@
     "@stepperize/react": "^3.0.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
     "lucide-react": "^0.439.0",
     "react": "^18.3.1",
+    "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
     "react-router-dom": "^6.26.1",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.23.8",
-    "vaul": "^0.9.4"
+    "vaul": "^0.9.4",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/components/forms/ExpenseForm.jsx
+++ b/src/components/forms/ExpenseForm.jsx
@@ -1,0 +1,126 @@
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import PropTypes from "prop-types"
+import { Button } from "../ui/button"
+// TODO import from src/lib/mock-data
+import { EXPENSE_CATEGORIES_MOCK, PARTICIPANTS_MOCK_DATA } from "@/pages/FirstGroupPage/mock-data"
+import { useState } from "react"
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover"
+import { cn } from "@/lib/utils"
+import { CalendarIcon, Percent } from "lucide-react"
+import { format } from "date-fns"
+import { Calendar } from "../ui/calendar"
+import { CONTRIBUTION_WEIGHTS } from "@/lib/constants"
+
+// TODO add default values prop (needed in case of edit
+export function ExpenseForm({ onSubmit, actions }) {
+  const [date, setDate] = useState()
+
+  return (
+    <form className="flex flex-col gap-4 md:grid md:grid-cols-2" onSubmit={onSubmit}>
+      <Label className="md:col-span-full">
+        <span className="sr-only">Expense name</span>
+        <Input name="expenseName" type="text" placeholder="Name" />
+      </Label>
+      <Label className="col-span-full">
+        <span className="sr-only">Expense description</span>
+        <Textarea name="expenseDescription" placeholder="Description" />
+      </Label>
+      <Label>
+        <span className="sr-only">Expense amount</span>
+        <Input name="expenseAmount" type="number" placeholder="Amount" />
+      </Label>
+      <Label>
+        <span className="sr-only">Expense category</span>
+        <Select name="expenseCategory">
+          <SelectTrigger>
+            <SelectValue placeholder="Category" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {EXPENSE_CATEGORIES_MOCK.map((category) => (
+                <SelectItem key={category} value={category}>
+                  {category}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </Label>
+      <Label>
+        <span className="sr-only">Select Purchaser</span>
+        <Select name="expensePurchaser">
+          <SelectTrigger>
+            <SelectValue placeholder="Purchaser" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {PARTICIPANTS_MOCK_DATA.map((participant) => (
+                <SelectItem
+                  key={participant.id}
+                  value={participant.firstName + " " + participant.lastName}
+                >
+                  {participant.firstName + " " + participant.lastName}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </Label>
+      <Label>
+        <span className="sr-only">Select the contribution weight</span>
+        <Select name="contribution">
+          <SelectTrigger>
+            <div className="flex items-center gap-4">
+              <Percent className="size-4" />
+              <SelectValue placeholder="Contribution Weight" />
+            </div>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {CONTRIBUTION_WEIGHTS.map((weight) => (
+                <SelectItem key={weight} value={weight}>
+                  {`${weight}%`}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </Label>
+      <Popover className="date-picker">
+        <PopoverTrigger asChild>
+          <Button
+            variant={"outline"}
+            className={cn("justify-start md:self-end", !date && "text-muted-foreground")}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date ? format(date, "PPP") : <span>Purchase date</span>}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="p-0">
+          <Calendar mode="single" selected={date} onSelect={setDate} initialFocus />
+        </PopoverContent>
+      </Popover>
+      <Label>
+        <span className="inline-block mb-2">Receipt proof (can be uploaded later)</span>
+        <Input name="expenseReceipt" type="file" />
+      </Label>
+      {actions ? actions : <Button type="submit">Submit</Button>}
+    </form>
+  )
+}
+
+ExpenseForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  actions: PropTypes.node,
+  // defaultValues: PropsTypes.
+}

--- a/src/components/forms/GroupDetailsForm.jsx
+++ b/src/components/forms/GroupDetailsForm.jsx
@@ -1,0 +1,63 @@
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import PropTypes from "prop-types"
+import { Button } from "../ui/button"
+// TODO import from src/lib/mock-data
+import { EXPENSE_GROUP_CATEGORIES_MOCK } from "@/pages/FirstGroupPage/mock-data"
+
+// TODO add default values prop (needed in case of edit action)
+export function GroupDetailsForm({ onSubmit, actions }) {
+  return (
+    <form className="flex flex-col gap-4 md:grid md:grid-cols-2" onSubmit={onSubmit}>
+      <Label className="col-span-full">
+        <span className="sr-only">Group name</span>
+        <Input type="text" name="groupName" placeholder="Name" />
+      </Label>
+      <Label className="col-span-full">
+        <span className="sr-only">Group description</span>
+        <Textarea name="groupDescription" placeholder="Description" />
+      </Label>
+      <Label>
+        <span className="sr-only">Allotted budget</span>
+        <Input type="number" name="groupAllottedBudget" placeholder="Allotted Budget" />
+      </Label>
+      <Label>
+        <span className="sr-only">Select a group category</span>
+        <Select name="groupCategory">
+          <SelectTrigger>
+            <SelectValue placeholder="Group Category" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {EXPENSE_GROUP_CATEGORIES_MOCK.map((category) => (
+                <SelectItem key={category} value={category}>
+                  {category}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </Label>
+      <Label className="hidden">
+        <span className="inline-block mb-2">Group avatar</span>
+        <Input name="groupAvatar" type="file" disabled />
+      </Label>
+      {actions ? actions : <Button type="submit">Submit</Button>}
+    </form>
+  )
+}
+
+GroupDetailsForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  actions: PropTypes.node,
+  // defaultValues: PropsTypes.
+}

--- a/src/components/forms/ParticipantForm.jsx
+++ b/src/components/forms/ParticipantForm.jsx
@@ -1,0 +1,65 @@
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Percent, Plus } from "lucide-react"
+import { CONTRIBUTION_WEIGHTS } from "@/lib/constants"
+import { Button } from "@/components/ui/button"
+import PropTypes from "prop-types"
+
+// TODO add default values prop (needed in case of edit
+export function ParticipantForm({ onSubmit, actions }) {
+  return (
+    <form
+      className="flex flex-col gap-4 md:grid grid-cols-[repeat(3,1fr)_auto]"
+      onSubmit={onSubmit}
+    >
+      <Label>
+        <span className="sr-only">Participant first name</span>
+        <Input name="firstName" type="text" placeholder="First Name" />
+      </Label>
+      <Label>
+        <span className="sr-only">Participant last name</span>
+        <Input name="lastName" type="text" placeholder="Last Name" />
+      </Label>
+      <Label>
+        <span className="sr-only">Select the contribution weight</span>
+        <Select name="contribution">
+          <SelectTrigger>
+            <div className="flex items-center gap-4">
+              <Percent className="size-4" />
+              <SelectValue placeholder="Contribution Weight" />
+            </div>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {CONTRIBUTION_WEIGHTS.map((weight) => (
+                <SelectItem key={weight} value={weight}>
+                  {`${weight}%`}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </Label>
+
+      <Button className="gap-2" type="button" variant="secondary">
+        Add<span className="md:hidden">&nbsp;participant</span>
+        <Plus className="hidden md:block size-4" />
+      </Button>
+      {actions ? actions : <Button type="submit">Submit</Button>}
+    </form>
+  )
+}
+
+ParticipantForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  actions: PropTypes.node,
+  // defaultValues: PropsTypes.
+}

--- a/src/components/ui/calendar.jsx
+++ b/src/components/ui/calendar.jsx
@@ -1,0 +1,62 @@
+/* eslint-disable no-unused-vars */
+import * as React from "react"
+import { ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons"
+import { DayPicker } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function Calendar({ className, classNames, showOutsideDays = true, ...props }) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        month: "space-y-4",
+        caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
+        nav_button: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+        ),
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full border-collapse space-y-1",
+        head_row: "flex",
+        head_cell: "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
+        row: "flex w-full mt-2",
+        cell: cn(
+          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected].day-range-end)]:rounded-r-md",
+          props.mode === "range"
+            ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
+            : "[&:has([aria-selected])]:rounded-md"
+        ),
+        day: cn(
+          buttonVariants({ variant: "ghost" }),
+          "h-8 w-8 p-0 font-normal aria-selected:opacity-100"
+        ),
+        day_range_start: "day-range-start",
+        day_range_end: "day-range-end",
+        day_selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        day_today: "bg-accent text-accent-foreground",
+        day_outside:
+          "day-outside text-muted-foreground opacity-50  aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
+        day_disabled: "text-muted-foreground opacity-50",
+        day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        day_hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        IconLeft: ({ ...props }) => <ChevronLeftIcon className="h-4 w-4" />,
+        IconRight: ({ ...props }) => <ChevronRightIcon className="h-4 w-4" />,
+      }}
+      {...props}
+    />
+  )
+}
+Calendar.displayName = "Calendar"
+
+export { Calendar }

--- a/src/pages/FirstGroupPage/FirstGroupPage.jsx
+++ b/src/pages/FirstGroupPage/FirstGroupPage.jsx
@@ -21,7 +21,6 @@ export function FirstGroupPage() {
       </Heading>
       <Scoped>
         <Steps />
-        <StepActions className="hidden lg:flex" />
       </Scoped>
     </>
   )
@@ -100,17 +99,17 @@ const StepsContent = ({ className, isCurrentStep, isStepBeforeLast, variant = "d
           })}
         >
           {stepper.when("first", () => (
-            <AddGroupDetailsStep includeActions />
+            <AddGroupDetailsStep />
           ))}
           {stepper.when("second", () => (
-            <AddParticipantsStep includeActions />
+            <AddParticipantsStep />
           ))}
           {stepper.when("third", () => (
-            <AddExpensesStep includeActions />
+            <AddExpensesStep />
           ))}
         </div>
       )}
-      {isCurrentStep && stepper.when("last", () => <LastStep includeActions />)}
+      {isCurrentStep && stepper.when("last", () => <LastStep />)}
     </div>
   ) : (
     <div className="hidden lg:block lg:mb-4">

--- a/src/pages/FirstGroupPage/components/AddExpensesStep.jsx
+++ b/src/pages/FirstGroupPage/components/AddExpensesStep.jsx
@@ -1,26 +1,16 @@
-import { Label } from "@/components/ui/label"
 import { useFirstGroupPageContext } from "../hooks/useFirstGroupPageContext"
 import { StepsContentCommonTypes } from "./types"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { StepActions } from "../FirstGroupPage"
-import { EXPENSE_CATEGORIES_MOCK } from "../mock-data"
 import { BodyText } from "@/components/Typography"
+import { ExpenseForm } from "@/components/forms/ExpenseForm"
 
-export function AddExpensesStep({ includeActions = false }) {
+export function AddExpensesStep() {
   const { useStepper } = useFirstGroupPageContext()
   const stepper = useStepper()
 
   const handleSubmit = (e) => {
     e.preventDefault()
+    console.log("expense form submit")
     // Do something
     stepper.next()
   }
@@ -30,42 +20,10 @@ export function AddExpensesStep({ includeActions = false }) {
       <BodyText variant="small" className="text-muted-foreground">
         {stepper.current.description}
       </BodyText>
-      <form className="flex flex-col gap-4 md:grid md:grid-cols-2" onSubmit={handleSubmit}>
-        <Label className="md:col-span-full">
-          <span className="sr-only">Expense name</span>
-          <Input name="expenseName" type="text" placeholder="Name" />
-        </Label>
-        <Label className="col-span-full">
-          <span className="sr-only">Expense description</span>
-          <Textarea name="expenseDescription" placeholder="Description" />
-        </Label>
-        <Label>
-          <span className="sr-only">Expense amount</span>
-          <Input name="expenseAmount" type="number" placeholder="Amount" />
-        </Label>
-        <Label>
-          <span className="sr-only">Expense category</span>
-          <Select name="expenseCategory">
-            <SelectTrigger>
-              <SelectValue placeholder="Category" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                {EXPENSE_CATEGORIES_MOCK.map((category) => (
-                  <SelectItem key={category} value={category}>
-                    {category}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </Label>
-        <Label>
-          <span className="inline-block mb-2">Receipt proof (can be uploaded later)</span>
-          <Input name="expenseReceipt" type="file" />
-        </Label>
-        {includeActions && <StepActions className="md:col-span-full" isWithinForm />}
-      </form>
+      <ExpenseForm
+        onSubmit={handleSubmit}
+        actions={<StepActions className="md:col-span-full" isWithinForm />}
+      />
     </>
   )
 }

--- a/src/pages/FirstGroupPage/components/AddGroupDetailsStep.jsx
+++ b/src/pages/FirstGroupPage/components/AddGroupDetailsStep.jsx
@@ -1,26 +1,16 @@
-import { Label } from "@/components/ui/label"
 import { useFirstGroupPageContext } from "../hooks/useFirstGroupPageContext"
 import { StepsContentCommonTypes } from "./types"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { EXPENSE_GROUP_CATEGORIES_MOCK } from "../mock-data"
 import { StepActions } from "../FirstGroupPage"
 import { BodyText } from "@/components/Typography"
+import { GroupDetailsForm } from "@/components/forms/GroupDetailsForm"
 
-export function AddGroupDetailsStep({ includeActions = false }) {
+export function AddGroupDetailsStep() {
   const { useStepper } = useFirstGroupPageContext()
   const stepper = useStepper()
 
   const handleSubmit = (e) => {
     e.preventDefault()
+    console.log("group details form submit")
     // Do something
     stepper.next()
   }
@@ -30,42 +20,10 @@ export function AddGroupDetailsStep({ includeActions = false }) {
       <BodyText variant="small" className="text-muted-foreground">
         {stepper.current.description}
       </BodyText>
-      <form className="flex flex-col gap-4 md:grid md:grid-cols-2" onSubmit={handleSubmit}>
-        <Label className="col-span-full">
-          <span className="sr-only">Group name</span>
-          <Input type="text" name="groupName" placeholder="Name" />
-        </Label>
-        <Label className="col-span-full">
-          <span className="sr-only">Group description</span>
-          <Textarea name="groupDescription" placeholder="Description" />
-        </Label>
-        <Label>
-          <span className="sr-only">Allotted budget</span>
-          <Input type="number" name="groupAllottedBudget" placeholder="Allotted Budget" />
-        </Label>
-        <Label>
-          <span className="sr-only">Select an expense category</span>
-          <Select name="groupCategory">
-            <SelectTrigger>
-              <SelectValue placeholder="Category" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                {EXPENSE_GROUP_CATEGORIES_MOCK.map((category) => (
-                  <SelectItem key={category} value={category}>
-                    {category}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </Label>
-        <Label className="hidden">
-          <span className="inline-block mb-2">Group avatar</span>
-          <Input name="groupAvatar" type="file" disabled />
-        </Label>
-        {includeActions && <StepActions className="col-span-full" isWithinForm />}
-      </form>
+      <GroupDetailsForm
+        onSubmit={handleSubmit}
+        actions={<StepActions className="md:col-span-full" isWithinForm />}
+      />
     </>
   )
 }

--- a/src/pages/FirstGroupPage/components/AddParticipantsStep.jsx
+++ b/src/pages/FirstGroupPage/components/AddParticipantsStep.jsx
@@ -1,27 +1,16 @@
-import { Label } from "@/components/ui/label"
 import { useFirstGroupPageContext } from "../hooks/useFirstGroupPageContext"
 import { StepsContentCommonTypes } from "./types"
-import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { StepActions } from "../FirstGroupPage"
-import { Percent, Plus } from "lucide-react"
-import { CONTRIBUTION_WEIGHTS } from "@/lib/constants"
-import { Button } from "@/components/ui/button"
 import { BodyText } from "@/components/Typography"
+import { ParticipantForm } from "@/components/forms/ParticipantForm"
 
-export function AddParticipantsStep({ includeActions = false }) {
+export function AddParticipantsStep() {
   const { useStepper } = useFirstGroupPageContext()
   const stepper = useStepper()
 
   const handleSubmit = (e) => {
     e.preventDefault()
+    console.log("participant form submit")
     // Do something
     stepper.next()
   }
@@ -31,45 +20,10 @@ export function AddParticipantsStep({ includeActions = false }) {
       <BodyText variant="small" className="text-muted-foreground">
         {stepper.current.description}
       </BodyText>
-      <form
-        className="flex flex-col gap-4 md:grid grid-cols-[repeat(3,1fr)_auto]"
+      <ParticipantForm
         onSubmit={handleSubmit}
-      >
-        <Label>
-          <span className="sr-only">Participant first name</span>
-          <Input name="firstName" type="text" placeholder="First Name" />
-        </Label>
-        <Label>
-          <span className="sr-only">Participant last name</span>
-          <Input name="lastName" type="text" placeholder="Last Name" />
-        </Label>
-        <Label>
-          <span className="sr-only">Select the contribution weight</span>
-          <Select name="contribution">
-            <SelectTrigger>
-              <div className="flex items-center gap-4">
-                <Percent className="size-4" />
-                <SelectValue placeholder="Contribution Weight" />
-              </div>
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                {CONTRIBUTION_WEIGHTS.map((weight) => (
-                  <SelectItem key={weight} value={weight}>
-                    {`${weight}%`}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </Label>
-
-        <Button className="gap-2" type="button" variant="secondary">
-          Add<span className="md:hidden">&nbsp;participant</span>
-          <Plus className="hidden md:block size-4" />
-        </Button>
-        {includeActions && <StepActions className="md:col-span-full" isWithinForm />}
-      </form>
+        actions={<StepActions className="md:col-span-full" isWithinForm />}
+      />
     </>
   )
 }

--- a/src/pages/FirstGroupPage/components/LastStep.jsx
+++ b/src/pages/FirstGroupPage/components/LastStep.jsx
@@ -1,13 +1,12 @@
 import { BodyText, Heading } from "@/components/Typography"
 import { useFirstGroupPageContext } from "../hooks/useFirstGroupPageContext"
 import { StepActions } from "../FirstGroupPage"
-import { StepsContentCommonTypes } from "./types"
 import { EXPENSES_MOCK_DATA, PARTICIPANTS_MOCK_DATA } from "../mock-data"
 import { ExpensesList } from "@/components/ExpensesList"
 import { GroupInfoWidget } from "@/components/GroupInfoWidget"
 import { SelectedParticipantsList } from "@/components/SelectedParticipantsList"
 
-export function LastStep({ includeActions = false }) {
+export function LastStep() {
   const { useStepper } = useFirstGroupPageContext()
   const stepper = useStepper()
 
@@ -42,9 +41,7 @@ export function LastStep({ includeActions = false }) {
         </section>
       ) : null}
 
-      {includeActions && <StepActions />}
+      <StepActions />
     </div>
   )
 }
-
-LastStep.propTypes = StepsContentCommonTypes


### PR DESCRIPTION
- Moved forms from each step in `FirstGroupPage` into separate components for better reusability across the app, including for edit and add new interfaces.
- Refactored action props to ensure proper handling of form behavior in different contexts.
- Added missing fields: purchaser, contribution weight, and purchase date.
- Installed the `shadcn` calendar needed for the date picker component.